### PR TITLE
Fix error message when calling extractFiles()

### DIFF
--- a/src/libarchive.js
+++ b/src/libarchive.js
@@ -101,10 +101,12 @@ export class Archive{
                 const [ target, prop ] = this._getProp(this._content,msg.entry.path);
                 if( msg.entry.type === 'FILE' ){
                     target[prop] = msg.entry.file;
-                    setTimeout(extractCallback.bind(null,{
-                        file: msg.entry.file,
-                        path: msg.entry.path,
-                    }));
+                    if (extractCallback !== undefined) {
+                        setTimeout(extractCallback.bind(null,{
+                            file: msg.entry.file,
+                            path: msg.entry.path,
+                        }));
+                    }
                 }
                 return true;
             }else if( msg.type === 'END' ){


### PR DESCRIPTION
When extractFiles is called without a callback (like in the example in the README) we would get the error message `TypeError: extractCallback is undefined` on the console.