### PR TITLE
Fix NodeJS not loading worker on Windows

### DIFF
--- a/src/libarchive-node.ts
+++ b/src/libarchive-node.ts
@@ -1,11 +1,12 @@
 import { Worker } from "worker_threads";
-import { URL } from "url";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
 import * as Comlink from "comlink";
 import nodeEndpoint from "comlink/dist/esm/node-adapter";
 import { Archive } from "./libarchive";
 export * from "./libarchive";
 
-const __dirname = new URL(".", import.meta.url).pathname;
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 Archive.init({
   getWorker: () => new Worker(`${__dirname}/worker-bundle-node.mjs`),


### PR DESCRIPTION
`new URL(".", import.meta.url).pathname` will return `/C:/xxxx.js/` on Windows, let's use the correct method to get the `__dirname` on all platforms.