### PR TITLE
Fix `file` type annotation of ArchiveEntryFile

### DIFF
--- a/dist/build/compiled/libarchive.d.ts
+++ b/dist/build/compiled/libarchive.d.ts
@@ -7,7 +7,7 @@ export type ArchiveOptions = {
     createClient?: (worker: any) => any;
 };
 export type ArchiveEntryFile = {
-    file: ArchiveEntryFile;
+    file: File;
     pathname?: string;
 };
 export type ArchiveWriteOptions = {

--- a/src/libarchive.ts
+++ b/src/libarchive.ts
@@ -10,7 +10,7 @@ export type ArchiveOptions = {
 };
 
 export type ArchiveEntryFile = {
-  file: ArchiveEntryFile;
+  file: File;
   pathname?: string;
 };
 


### PR DESCRIPTION
The `file` field is actually meant to be a `File`, not an `ArchiveEntryFile`. It would otherwise be impossible to construct an `ArchiveEntryFile`.